### PR TITLE
Add prefix to discovered IP address

### DIFF
--- a/netbox-scanner/nbscanner
+++ b/netbox-scanner/nbscanner
@@ -58,6 +58,8 @@ except KeyError:
 argp = ArgumentParser()
 argp.add_argument('-c', '--csv', 
     help='import CSV file instead of scan network', default=None)
+argp.add_argument('-p', '--add-prefix', action="store_true",
+    help='Add the prefix to the scanned IP rather than using /32', default=None)
 args = argp.parse_args()
 
 logfile = '{}/netbox-scanner-{}.log'.format(general_conf['log'],
@@ -71,8 +73,11 @@ if __name__ == '__main__':
     nbs = NetBoxScanner(netbox_conf['address'], netbox_conf['token'], 
         netbox_conf.getboolean('tls_verify'), general_conf['nmap_args'], 
         tacacs_conf, general_conf['tag'], general_conf['unknown'])
+    args_prefix = False
+    if args.add_prefix:
+        args_prefix = True
     if not args.csv:
-        nbs.sync(networks)
+        nbs.sync(networks, args_prefix)
     else:
         nbs.sync_csv(args.csv)
     exit(0)

--- a/netbox-scanner/nbscanner.py
+++ b/netbox-scanner/nbscanner.py
@@ -129,6 +129,8 @@ class NetBoxScanner(object):
         '''
         try:
             nbhost = self.netbox.ipam.ip_addresses.get(address=host[0])
+            prefix = str(self.netbox.ipam.prefixes.get(contains=host[0]))
+            prefix = prefix.split("/")
         except ValueError:
             self.logger('duplicated', address=host[0])
             return False
@@ -140,9 +142,9 @@ class NetBoxScanner(object):
                 self.logger('updated', address=host[0], description_old=aux, 
                     description_new=host[1])
         else:
-            self.netbox.ipam.ip_addresses.create(address=host[0], 
+            self.netbox.ipam.ip_addresses.create(address=host[0] + "/" + str(prefix[1]), 
                 tags=[self.tag], description=host[1])
-            self.logger('created', address=host[0], description=host[1])
+            self.logger('created', address=host[0] + "/" + str(prefix[1]), description=host[1])
         return True
     
     def sync_network(self, network):


### PR DESCRIPTION
This will add the prefix when adding a IP to netbox which will put the IP addresses into the correct prefix.
Before, IP addresses would not get added into the correct prefix due to the /32 subnet mask.