### PR TITLE
update: README + netbox 2.9.x compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ $ pip install -r requirements.txt
 
 After installation, use the `netbox-scanner.conf` file as an example to create your own and put this file in `/opt/netbox` or prepend its name with a dot and put it in your home directory --`~/.netbox-scanner.conf`.  Keep reading to learn more about configuration.
 
+> Starting with Netbox **v2.9.0** there are changes to the way tags are created. You must go into the web UI and explicity create a tag for each module you are planning to use here. So for example, if you want to use the nmap module, you have to create a Netbox tag called 'nmap' before you can successfully use it.
+
+## Quick Start
+
+0. Clone the repo and install the dependencies as shown above.
+1. Move the `netbox-scanner.conf` file to your Netbox directory (`/opt/netbox`) and fill out the variables according to your setup.
+2. Go to the `samples` subdirectory of this repo and execute `./nmap-scan.sh` to get a first look at the behavior of this project.
 
 ## Basics
 netbox-scanner reads a user-defined source to discover IP addresses and descriptions, and insert them into NetBox.  To control what was previously inserted, netbox-scanner adds tags to each record, so it will know that that item can be handled.  In order to guarantee the integrity of manual inputs, records without such tags will not be updated or removed.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ netbox-scanner is compatible with **Python 3.7+**, and can be installed like thi
 $ wget https://github.com/lopes/netbox-scanner/archive/master.zip
 $ unzip netbox-scanner-master.zip -d netbox-scanner
 $ cd netbox-scanner
+$ python3 -m venv venv
+$ source venv/bin/activate
 $ pip install -r requirements.txt
 ```
 
@@ -21,7 +23,7 @@ After installation, use the `netbox-scanner.conf` file as an example to create y
 ## Quick Start
 
 0. Clone the repo and install the dependencies as shown above.
-1. Move the `netbox-scanner.conf` file to your Netbox directory (`/opt/netbox`) and fill out the variables according to your setup.
+1. Move the `netbox-scanner.conf` file to your Netbox directory (`/opt/netbox`) and fill out the variables according to your setup. Don't forget to change the path to match where you put this repo under `[NMAP].path`.
 2. Go to the `samples` subdirectory of this repo and execute `./nmap-scan.sh` to get a first look at the behavior of this project.
 
 ## Basics

--- a/nbs/__init__.py
+++ b/nbs/__init__.py
@@ -4,7 +4,7 @@ from pynetbox import api
 
 
 class NetBoxScanner(object):
-    
+
     def __init__(self, address, token, tls_verify, tag, cleanup):
         self.netbox = api(address, token, ssl_verify=tls_verify)
         self.tag = tag
@@ -46,15 +46,15 @@ class NetBoxScanner(object):
                     self.stats['unchanged'] += 1
         else:
             self.netbox.ipam.ip_addresses.create(
-                address=host[0], 
-                tags=[self.tag],
+                address=host[0],
+                # tags=[self.tag],
                 description=host[1]
             )
             logging.info(f'created: {host[0]}/32 "{host[1]}"')
             self.stats['created'] += 1
 
         return True
-    
+
     def garbage_collector(self, hosts):
         '''Removes records from NetBox not found in last sync'''
         nbhosts = self.netbox.ipam.ip_addresses.filter(tag=self.tag)
@@ -83,8 +83,9 @@ class NetBoxScanner(object):
             self.stats['unchanged'],
             self.stats['created'],
             self.stats['updated'],
-            self.stats['deleted'], 
+            self.stats['deleted'],
             self.stats['errors']
         ))
 
         return True
+

--- a/netbox-scanner.conf
+++ b/netbox-scanner.conf
@@ -5,7 +5,7 @@ tls_verify = no
 logs       = .
 
 [NMAP]
-path     = samples/nmap
+path     = /opt/netbox-scanner/samples/nmap
 unknown  = autodiscovered:netbox-scanner
 tag      = nmap
 cleanup  = yes

--- a/samples/nmap-scan.sh
+++ b/samples/nmap-scan.sh
@@ -20,7 +20,7 @@ NETWORKS="10.1.2.3/24 10.2.3.4/32 192.168.0.0/19"
 TODAY="$(date +%d%m%yT%H%M%S%Z)"
 
 for net in $NETWORKS; do
-	rawNet="${net:0:-3}"
+  rawNet="${net:0:-3}"
   sudo nmap -T4 -O -F --host-timeout 30s -oX nmap-"$rawNet".xml "$net"
 done
 

--- a/samples/nmap-scan.sh
+++ b/samples/nmap-scan.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # This is just an example. 
 #
@@ -16,11 +16,12 @@
 # to look for XML files.
 ##
 
-NETWORKS = "10.1.2.3/24 10.2.3.4/32 192.168.0.0/19"
-TODAY="$(date +%d.%m.%yT%H:%M:%S%Z)"
+NETWORKS="10.1.2.3/24 10.2.3.4/32 192.168.0.0/19"
+TODAY="$(date +%d%m%yT%H%M%S%Z)"
 
 for net in $NETWORKS; do
-    nmap -T4 -O -F --host-timeout 30s -oX nmap-"$net".xml
+	rawNet="${net:0:-3}"
+  sudo nmap -T4 -O -F --host-timeout 30s -oX nmap-"$rawNet".xml "$net"
 done
 
 python ../netbox-scanner.py nmap


### PR DESCRIPTION
So based upon the comments in #20 and my work getting this to work recently I made a few changes, hope you don't mind!

1. Updated the README with info about manual tag creation and "Quick Start", because I found it difficult to decipher how to actually run the thing. Oh and I added instructions to create a venv before installing, standard python best practices.
2. I commented out the line about tags when creating new IPs in `nbs/__init__.py` for now because the subroutine you mentioned to get the existing tag ID and use that instead doesn't exist yet and I'm not experienced enough with python to write it. This way it runs with current (and older) Netbox at least.
3. I specified the full path to the directory and added the `samples/nmap` subdirectory already so people don't get confused (also the program was confused without the full path for me in that variable in the conf).
4. Then I made a few changes to the `nmap-scan.sh` script. First of all, your shebang for just 'sh' didn't work on mine and my colleagues machine because sh wasn't symlinked to bash. The best practice here is to use `#!/usr/bin/env bash`. Also the `NETWORKS` variable isnt actually declared if you put spaces around the `=`, so I removed those. In addition, nmap wouldn't write a filename with an unescaped `\` in it (from the full `$net` variable) so I made a temporary `$rawNet` variable which just chops off the last 3 chars of `$net` and writes the nmap file with the IP as suffix. Oh also tar was complaining because of unescaped `.` and `:` as well, so I dropped those from the `TODAY` variable.

This way it finally ran on my system on the latest Netbox (2.9.9) and it should still be compatible with older versions.

Like you mentioned in that issue, a real function to grab the ID of the required tag and use that in place of the name so we can uncomment that line again would be crucial. 

Thanks 🎉